### PR TITLE
Add Breadcrumb component to LayoutLogin and remove unused import in R…

### DIFF
--- a/src/app/[locale]/(auth)/register/page.tsx
+++ b/src/app/[locale]/(auth)/register/page.tsx
@@ -8,7 +8,6 @@ import useTheme from "@/hooks/useTheme";
 import LayoutLogin from "@/layout/Login/layoutLogin";
 import { InputForm } from "@/components/molecules/InputForm";
 import { SyncLoader } from "react-spinners";
-import Breadcrumb from "@/components/atoms/breadcrumb";
 
 interface Register {
   email: string;

--- a/src/layout/Login/layoutLogin.tsx
+++ b/src/layout/Login/layoutLogin.tsx
@@ -9,6 +9,7 @@ import { Sun, Moon } from "lucide-react";
 import { IoEarth } from "react-icons/io5";
 import { useTranslations } from "next-intl";
 import SelectList from "@/components/atoms/SelectList";
+import Breadcrumb from "@/components/atoms/breadcrumb";
 
 interface LayoutLoginProps {
   children: ReactNode;
@@ -63,6 +64,7 @@ function LayoutLogin({ children }: LayoutLoginProps) {
       <header
         className={`fixed top-0 z-30 flex flex-row justify-between items-center pl-10 pr-16 py-3 w-full transition-colors duration-500 ${bgHeader}`}
       >
+        <Breadcrumb />
         <section className="flex gap-4 justify-center items-center">
           <Image
             src={Logo}


### PR DESCRIPTION
This pull request refactors the breadcrumb component integration within the authentication pages. The changes involve moving the `Breadcrumb` component from the `register` page to the `LayoutLogin` component, ensuring consistent breadcrumb functionality across all pages using the login layout.

### Breadcrumb Component Refactor:

* Removed `Breadcrumb` import from the `register` page (`src/app/[locale]/(auth)/register/page.tsx`) as it is no longer used directly there. ([src/app/[locale]/(auth)/register/page.tsxL11](diffhunk://#diff-a28f3e000d6ee9161b4a60f4b3e82020be2e7eb166c530ad6415a130ffa34a93L11))
* Added `Breadcrumb` import to the `LayoutLogin` component for centralized usage (`src/layout/Login/layoutLogin.tsx`).
* Integrated the `Breadcrumb` component into the `LayoutLogin` header, ensuring it is displayed consistently across all pages using this layout.